### PR TITLE
add backward support for M1.8

### DIFF
--- a/src/app/code/local/MageProfis/MegaMenu/Block/Submenu.php
+++ b/src/app/code/local/MageProfis/MegaMenu/Block/Submenu.php
@@ -23,7 +23,7 @@ class MageProfis_MegaMenu_Block_Submenu extends Mage_Core_Block_Template
                 ->addAttributeToFilter('include_in_menu', 1)
                 ->addAttributeToSort('position', 'ASC')
                 ->addIsActiveFilter()
-                ->joinUrlRewrite();       
+                ->addUrlRewriteToResult();       
                 
         return $categoryCollection;          
     }


### PR DESCRIPTION
joinUrlRewrite is a alias for the function addUrlRewriteToResult.
joinUrlRewrite does not exist in Magento 1.8...
